### PR TITLE
Fix license header to remove invalid modification to license

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2,8 +2,7 @@
 
 # Copyright (c) 2021 vesoft inc. All rights reserved.
 #
-# This source code is licensed under Apache 2.0 License,
-# attached with Common Clause Condition 1.0, found in the LICENSES directory.
+# This source code is licensed under Apache 2.0 License
 
 $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
You can't modify the Apache License.

That is - you can't restrict your license by adding the Common Clause and still claim to have an Apache license.

See https://github.com/vesoft-inc/nebula/issues/3247